### PR TITLE
Modified limits to cpu and memory to 1.2x per NRP requirements

### DIFF
--- a/globus/globus-connect.yaml
+++ b/globus/globus-connect.yaml
@@ -20,12 +20,13 @@ spec:
         image: gitlab-registry.nrp-nautilus.io/prp/globus-connect:7f540862
         # image: gitlab-registry.nrp-nautilus.io/prp/globus-connect
         resources:
+          # limits can only be 1.2 the requests per NRP rules        
           limits:
-            memory: 1Gi
-            cpu: 1
+            memory: 1.2G
+            cpu: 1200m
           requests:
-            memory: 100Mi
-            cpu: 100m
+            memory: 1G
+            cpu: 1
         ports:
         - containerPort: 80
           name: web

--- a/jupyterhub/jupyter-pod-L40.yaml
+++ b/jupyterhub/jupyter-pod-L40.yaml
@@ -29,13 +29,14 @@ spec:
         image: henrylisdsu/climate-lab-notebook:v1.3
         command: ["jupyter", "lab", "--ip='0.0.0.0'"]
         resources:
+          # limits can only be 1.2 the requests per NRP rules
           limits:
-            cpu: "2"
-            memory: 4Gi
+            cpu: "2.4"
+            memory: 9.6G
             nvidia.com/gpu: 1
           requests:
-            cpu: "1"
-            memory: 1Gi
+            cpu: "2"
+            memory: 8G
             nvidia.com/gpu: 1
         volumeMounts:
         - mountPath: /home/jovyan


### PR DESCRIPTION
Used G instead of Gi as 0.2 in based 2 does not terminate 